### PR TITLE
fix: update variable types for settings and protected_settings in vmss

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -98,8 +98,8 @@ variable "vmss" {
       publisher                   = string
       type                        = string
       type_handler_version        = string
-      settings                    = optional(map(any), {})
-      protected_settings          = optional(map(string), {})
+      settings                    = optional(any, {})
+      protected_settings          = optional(any, {})
       auto_upgrade_minor_version  = optional(bool, true)
       automatic_upgrade_enabled   = optional(bool, false)
       failure_suppression_enabled = optional(bool, false)


### PR DESCRIPTION
## Description

fix type definition for extension settings and protected settings. Multiple types are now allowed for more complex configurations


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules