### PR TITLE
fix: jsonencoded settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -710,8 +710,8 @@ resource "azurerm_virtual_machine_scale_set_extension" "ext" {
   type                         = each.value.type
   type_handler_version         = each.value.type_handler_version
   auto_upgrade_minor_version   = each.value.auto_upgrade_minor_version
-  settings                     = jsonencode(each.value.settings)
-  protected_settings           = jsonencode(each.value.protected_settings)
+  settings                   = length(try(each.value.settings, {})) > 0 ? jsonencode(each.value.settings) : null
+  protected_settings         = length(try(each.value.protected_settings, {})) > 0 ? jsonencode(each.value.protected_settings) : null
 
   force_update_tag            = each.value.force_update_tag
   provision_after_extensions  = each.value.provision_after_extensions

--- a/main.tf
+++ b/main.tf
@@ -710,8 +710,8 @@ resource "azurerm_virtual_machine_scale_set_extension" "ext" {
   type                         = each.value.type
   type_handler_version         = each.value.type_handler_version
   auto_upgrade_minor_version   = each.value.auto_upgrade_minor_version
-  settings                   = length(try(each.value.settings, {})) > 0 ? jsonencode(each.value.settings) : null
-  protected_settings         = length(try(each.value.protected_settings, {})) > 0 ? jsonencode(each.value.protected_settings) : null
+  settings                     = length(try(each.value.settings, {})) > 0 ? jsonencode(each.value.settings) : null
+  protected_settings           = length(try(each.value.protected_settings, {})) > 0 ? jsonencode(each.value.protected_settings) : null
 
   force_update_tag            = each.value.force_update_tag
   provision_after_extensions  = each.value.provision_after_extensions


### PR DESCRIPTION
## Description

* When no value is given for settings/protected_settings, default to null instead of jsonencode({}) as this is causing issues for extensions

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Change Log

* When no value is given for settings/protected_settings, default to null instead of jsonencode({}) as this is causing issues for extensions

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)
